### PR TITLE
動画再生画面への遷移機能を実装

### DIFF
--- a/Domain/src/main/java/com/neesan/domain/search/VideoDomainModel.kt
+++ b/Domain/src/main/java/com/neesan/domain/search/VideoDomainModel.kt
@@ -1,5 +1,7 @@
 package com.neesan.domain.search
 
+import java.io.Serializable
+
 /**
  * 動画のドメインモデル
  */
@@ -9,7 +11,7 @@ data class VideoDomainModel(
     val viewCount: Int,
     val thumbnailUrl: String,
     val isFavorite: Boolean = false
-) {
+) : Serializable {
     companion object {
         fun ofDefault() = VideoDomainModel(
             id = "sm12345678",

--- a/Presentation/src/main/java/com/neesan/presentation/MainScreen.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/MainScreen.kt
@@ -19,6 +19,9 @@ import com.neesan.presentation.favorite.FavoriteDestination
 import com.neesan.presentation.favorite.FavoriteScreen
 import com.neesan.presentation.search.SearchDestination
 import com.neesan.presentation.search.SearchScreen
+import com.neesan.presentation.videoplayer.VideoPlayerDestination
+import com.neesan.presentation.videoplayer.VideoPlayerScreen
+import com.neesan.domain.search.VideoDomainModel
 
 /**
  * メイン画面。下部のタブで検索画面とお気に入り画面を切り替える。
@@ -67,10 +70,24 @@ fun MainScreen() {
             modifier = Modifier.padding(innerPadding)
         ) {
             composable<SearchDestination> {
-                SearchScreen()
+                SearchScreen(
+                    onVideoClick = { video ->
+                        navController.currentBackStackEntry?.savedStateHandle?.set("video", video)
+                        navController.navigate(VideoPlayerDestination)
+                    }
+                )
             }
             composable<FavoriteDestination> {
-                FavoriteScreen()
+                FavoriteScreen(
+                    onVideoClick = { video ->
+                        navController.currentBackStackEntry?.savedStateHandle?.set("video", video)
+                        navController.navigate(VideoPlayerDestination)
+                    }
+                )
+            }
+            composable<VideoPlayerDestination> { backStackEntry ->
+                val video = backStackEntry.savedStateHandle.get<VideoDomainModel>("video")
+                VideoPlayerScreen(video)
             }
         }
     }

--- a/Presentation/src/main/java/com/neesan/presentation/MainScreen.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/MainScreen.kt
@@ -21,7 +21,7 @@ import com.neesan.presentation.search.SearchDestination
 import com.neesan.presentation.search.SearchScreen
 import com.neesan.presentation.videoplayer.VideoPlayerDestination
 import com.neesan.presentation.videoplayer.VideoPlayerScreen
-import com.neesan.domain.search.VideoDomainModel
+import androidx.navigation.toRoute
 
 /**
  * メイン画面。下部のタブで検索画面とお気に入り画面を切り替える。
@@ -72,22 +72,34 @@ fun MainScreen() {
             composable<SearchDestination> {
                 SearchScreen(
                     onVideoClick = { video ->
-                        navController.currentBackStackEntry?.savedStateHandle?.set("video", video)
-                        navController.navigate(VideoPlayerDestination)
+                        navController.navigate(
+                            VideoPlayerDestination(
+                                videoId = video.id,
+                                title = video.title,
+                                thumbnailUrl = video.thumbnailUrl,
+                                isFavorite = video.isFavorite
+                            )
+                        )
                     }
                 )
             }
             composable<FavoriteDestination> {
                 FavoriteScreen(
                     onVideoClick = { video ->
-                        navController.currentBackStackEntry?.savedStateHandle?.set("video", video)
-                        navController.navigate(VideoPlayerDestination)
+                        navController.navigate(
+                            VideoPlayerDestination(
+                                videoId = video.id,
+                                title = video.title,
+                                thumbnailUrl = video.thumbnailUrl,
+                                isFavorite = video.isFavorite
+                            )
+                        )
                     }
                 )
             }
             composable<VideoPlayerDestination> { backStackEntry ->
-                val video = backStackEntry.savedStateHandle.get<VideoDomainModel>("video")
-                VideoPlayerScreen(video)
+                val destination = backStackEntry.toRoute<VideoPlayerDestination>()
+                VideoPlayerScreen(destination)
             }
         }
     }

--- a/Presentation/src/main/java/com/neesan/presentation/favorite/FavoriteScreen.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/favorite/FavoriteScreen.kt
@@ -25,6 +25,8 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.ui.graphics.vector.ImageVector
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import com.neesan.domain.search.VideoDomainModel
+import com.neesan.domain.favorite.FavoriteVideoDomainData
 
 /**
  * お気に入り画面の遷移先情報
@@ -39,6 +41,7 @@ object FavoriteDestination : NavigationDestination {
 
 @Composable
 fun FavoriteScreen(
+    onVideoClick: (VideoDomainModel) -> Unit = {},
     viewModel: FavoriteVideoViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -46,7 +49,8 @@ fun FavoriteScreen(
         uiState = uiState,
         onRemoveFavorite = viewModel::removeFavoriteVideoById,
         onClearError = viewModel::clearError,
-        onRetry = viewModel::loadFavoriteVideos
+        onRetry = viewModel::loadFavoriteVideos,
+        onVideoClick = onVideoClick
     )
 }
 
@@ -56,7 +60,8 @@ private fun FavoriteContent(
     uiState: FavoriteVideoUiState,
     onRemoveFavorite: (String) -> Unit,
     onClearError: () -> Unit,
-    onRetry: () -> Unit
+    onRetry: () -> Unit,
+    onVideoClick: (VideoDomainModel) -> Unit = {}
 ) {
     Scaffold(
         topBar = {
@@ -90,7 +95,17 @@ private fun FavoriteContent(
 
             FavoriteResultsSection(
                 uiState = uiState,
-                onRemoveFavorite = onRemoveFavorite
+                onRemoveFavorite = onRemoveFavorite,
+                onVideoClick = { favoriteVideo: FavoriteVideoDomainData ->
+                    val video = VideoDomainModel(
+                        id = favoriteVideo.videoId,
+                        title = favoriteVideo.title,
+                        viewCount = 0,
+                        thumbnailUrl = favoriteVideo.thumbnailUrl,
+                        isFavorite = true
+                    )
+                    onVideoClick(video)
+                }
             )
         }
     }
@@ -105,6 +120,7 @@ private fun PreviewFavoriteContent() {
         uiState = previewState,
         onRemoveFavorite = {},
         onClearError = {},
-        onRetry = {}
+        onRetry = {},
+        onVideoClick = {}
     )
 }

--- a/Presentation/src/main/java/com/neesan/presentation/favorite/component/FavoriteVideoItemComponent.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/favorite/component/FavoriteVideoItemComponent.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Card
@@ -33,10 +34,13 @@ import java.util.Locale
 @Composable
 fun FavoriteVideoItemComponent(
     favoriteVideo: FavoriteVideoDomainData,
-    onRemoveFavorite: (String) -> Unit
+    onRemoveFavorite: (String) -> Unit,
+    onVideoClick: (FavoriteVideoDomainData) -> Unit = {}
 ) {
     Card(
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onVideoClick(favoriteVideo) }
     ) {
         Row(
             modifier = Modifier
@@ -105,6 +109,7 @@ private fun formatDate(timestamp: Long): String {
 private fun PreviewFavoriteVideoItemComponent() {
     FavoriteVideoItemComponent(
         favoriteVideo = FavoriteVideoDomainData.ofDefault(),
-        onRemoveFavorite = {}
+        onRemoveFavorite = {},
+        onVideoClick = {}
     )
 }

--- a/Presentation/src/main/java/com/neesan/presentation/favorite/section/FavoriteResultsSection.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/favorite/section/FavoriteResultsSection.kt
@@ -16,11 +16,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.neesan.presentation.favorite.FavoriteVideoUiState
 import com.neesan.presentation.favorite.component.FavoriteVideoItemComponent
+import com.neesan.domain.favorite.FavoriteVideoDomainData
 
 @Composable
 fun FavoriteResultsSection(
     uiState: FavoriteVideoUiState,
-    onRemoveFavorite: (String) -> Unit
+    onRemoveFavorite: (String) -> Unit,
+    onVideoClick: (FavoriteVideoDomainData) -> Unit = {}
 ) {
     when {
         uiState.isFavoriteEmpty && !uiState.isLoading -> {
@@ -48,7 +50,8 @@ fun FavoriteResultsSection(
                     items(uiState.favoriteVideos) { favoriteVideo ->
                         FavoriteVideoItemComponent(
                             favoriteVideo = favoriteVideo,
-                            onRemoveFavorite = onRemoveFavorite
+                            onRemoveFavorite = onRemoveFavorite,
+                            onVideoClick = onVideoClick
                         )
                     }
                 }
@@ -63,6 +66,7 @@ private fun PreviewFavoriteResultsSection() {
     val previewState = FavoriteVideoUiState.ofDefault()
     FavoriteResultsSection(
         uiState = previewState,
-        onRemoveFavorite = {}
+        onRemoveFavorite = {},
+        onVideoClick = {}
     )
 }

--- a/Presentation/src/main/java/com/neesan/presentation/search/SearchScreen.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/search/SearchScreen.kt
@@ -40,6 +40,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.neesan.presentation.search.section.SearchResultsSection
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import com.neesan.domain.search.VideoDomainModel
 
 /**
  * 検索画面の遷移先情報
@@ -57,6 +58,7 @@ object SearchDestination : NavigationDestination {
  */
 @Composable
 fun SearchScreen(
+    onVideoClick: (VideoDomainModel) -> Unit = {},
     viewModel: SearchVideoViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -67,7 +69,8 @@ fun SearchScreen(
         onNotificationRequestFinish = {
             viewModel.updateNotificationPermissionRequested()
         },
-        onFavoriteToggle = viewModel::toggleFavorite
+        onFavoriteToggle = viewModel::toggleFavorite,
+        onVideoClick = onVideoClick
     )
 }
 
@@ -78,7 +81,8 @@ private fun SearchContent(
     onSearch: (String) -> Unit,
     onClearSearch: () -> Unit,
     onNotificationRequestFinish: () -> Unit = {},
-    onFavoriteToggle: (com.neesan.domain.search.VideoDomainModel) -> Unit = {}
+    onFavoriteToggle: (VideoDomainModel) -> Unit = {},
+    onVideoClick: (VideoDomainModel) -> Unit = {}
 ) {
     var searchQuery by remember { mutableStateOf("") }
 
@@ -155,7 +159,8 @@ private fun SearchContent(
             }
             SearchResultsSection(
                 uiState = uiState,
-                onFavoriteToggle = onFavoriteToggle
+                onFavoriteToggle = onFavoriteToggle,
+                onVideoClick = onVideoClick
             )
         }
     }
@@ -172,6 +177,7 @@ private fun PreviewSearchContent() {
     SearchContent(
         uiState = previewState,
         onSearch = {},
-        onClearSearch = {}
+        onClearSearch = {},
+        onVideoClick = {}
     )
 }

--- a/Presentation/src/main/java/com/neesan/presentation/search/component/VideoItemRowComponent.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/search/component/VideoItemRowComponent.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
@@ -36,10 +37,13 @@ import com.neesan.domain.search.VideoDomainModel
 fun VideoItemRowComponent(
     video: VideoDomainModel,
     isFavorite: Boolean = false,
-    onFavoriteToggle: (VideoDomainModel) -> Unit = {}
+    onFavoriteToggle: (VideoDomainModel) -> Unit = {},
+    onVideoClick: (VideoDomainModel) -> Unit = {}
 ) {
     Card(
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onVideoClick(video) }
     ) {
         Row(
             modifier = Modifier
@@ -121,6 +125,7 @@ private fun formatViewCount(count: Int): String {
 @Composable
 private fun PreviewVideoItemRowComponent() {
     VideoItemRowComponent(
-        video = VideoDomainModel.ofDefault()
+        video = VideoDomainModel.ofDefault(),
+        onVideoClick = {}
     )
 }

--- a/Presentation/src/main/java/com/neesan/presentation/search/section/SearchResultsSection.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/search/section/SearchResultsSection.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.neesan.presentation.search.SearchVideoUiState
 import com.neesan.presentation.search.component.VideoItemRowComponent
+import com.neesan.domain.search.VideoDomainModel
 
 /**
  * 検索画面
@@ -23,7 +24,8 @@ import com.neesan.presentation.search.component.VideoItemRowComponent
 @Composable
 fun SearchResultsSection(
     uiState: SearchVideoUiState,
-    onFavoriteToggle: (com.neesan.domain.search.VideoDomainModel) -> Unit = {}
+    onFavoriteToggle: (VideoDomainModel) -> Unit = {},
+    onVideoClick: (VideoDomainModel) -> Unit = {}
 ) {
     // 検索結果
     when {
@@ -66,7 +68,8 @@ fun SearchResultsSection(
                         VideoItemRowComponent(
                             video = video,
                             isFavorite = video.isFavorite,
-                            onFavoriteToggle = onFavoriteToggle
+                            onFavoriteToggle = onFavoriteToggle,
+                            onVideoClick = onVideoClick
                         )
                     }
                 }
@@ -83,6 +86,7 @@ fun SearchResultsSection(
 private fun PreviewSearchResultsSection() {
     val previewState = SearchVideoUiState.ofDefault()
     SearchResultsSection(
-        uiState = previewState
+        uiState = previewState,
+        onVideoClick = {}
     )
 }

--- a/Presentation/src/main/java/com/neesan/presentation/videoplayer/VideoPlayerDestination.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/videoplayer/VideoPlayerDestination.kt
@@ -1,0 +1,20 @@
+package com.neesan.presentation.videoplayer
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.neesan.presentation.NavigationDestination
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+/**
+ * 動画再生画面の遷移先情報
+ */
+@Serializable
+object VideoPlayerDestination : NavigationDestination {
+    override val route: String = "video_player"
+    override val label: String = "動画再生"
+
+    @Transient
+    override val icon: ImageVector = Icons.Filled.PlayArrow
+} 

--- a/Presentation/src/main/java/com/neesan/presentation/videoplayer/VideoPlayerDestination.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/videoplayer/VideoPlayerDestination.kt
@@ -1,20 +1,16 @@
 package com.neesan.presentation.videoplayer
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.ui.graphics.vector.ImageVector
-import com.neesan.presentation.NavigationDestination
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.Transient
 
 /**
- * 動画再生画面の遷移先情報
+ * 動画再生画面の遷移に使用する型安全ルート。
+ * 必要最小限として動画 ID とタイトル、サムネイル URL、
+ * お気に入り状態のみを渡すようにしています。
  */
 @Serializable
-object VideoPlayerDestination : NavigationDestination {
-    override val route: String = "video_player"
-    override val label: String = "動画再生"
-
-    @Transient
-    override val icon: ImageVector = Icons.Filled.PlayArrow
-} 
+data class VideoPlayerDestination(
+    val videoId: String,
+    val title: String,
+    val thumbnailUrl: String = "",
+    val isFavorite: Boolean = false
+) 

--- a/Presentation/src/main/java/com/neesan/presentation/videoplayer/VideoPlayerScreen.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/videoplayer/VideoPlayerScreen.kt
@@ -3,18 +3,17 @@ package com.neesan.presentation.videoplayer
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.neesan.domain.search.VideoDomainModel
 
 /**
  * 動画再生画面。現状はプレースホルダーとして動画タイトルを表示するのみ。
  */
 @Composable
-fun VideoPlayerScreen(video: VideoDomainModel?) {
-    Text(text = "動画再生画面: ${video?.title ?: "No video"}")
+fun VideoPlayerScreen(destination: VideoPlayerDestination) {
+    Text(text = "動画再生画面: ${destination.title}")
 }
 
 @Preview(showBackground = true)
 @Composable
 private fun PreviewVideoPlayerScreen() {
-    VideoPlayerScreen(VideoDomainModel.ofDefault())
+    VideoPlayerScreen(VideoPlayerDestination(videoId = "sm12345678", title = "サンプル動画", thumbnailUrl = ""))
 } 

--- a/Presentation/src/main/java/com/neesan/presentation/videoplayer/VideoPlayerScreen.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/videoplayer/VideoPlayerScreen.kt
@@ -1,0 +1,20 @@
+package com.neesan.presentation.videoplayer
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.neesan.domain.search.VideoDomainModel
+
+/**
+ * 動画再生画面。現状はプレースホルダーとして動画タイトルを表示するのみ。
+ */
+@Composable
+fun VideoPlayerScreen(video: VideoDomainModel?) {
+    Text(text = "動画再生画面: ${video?.title ?: "No video"}")
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewVideoPlayerScreen() {
+    VideoPlayerScreen(VideoDomainModel.ofDefault())
+} 


### PR DESCRIPTION
## Summary
- 動画再生画面への遷移機能を実装
- パラメータ渡し機能を追加
- 検索画面とお気に入り画面から動画再生画面への遷移を可能にした

## 主な変更内容
- VideoPlayerDestination, VideoPlayerScreenを作成
- 検索結果とお気に入りリストから動画詳細への遷移を実装
- Navigationライブラリによるパラメータベースの画面遷移を追加
- VideoDomainModelの更新

## Test plan
- [x] 検索画面から動画アイテムをタップして動画再生画面に遷移できることを確認
- [x] お気に入り画面から動画アイテムをタップして動画再生画面に遷移できることを確認
- [x] 動画再生画面で正しいパラメータが受け取れることを確認
- [x] アプリのビルドが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)