### PR TITLE
お気に入りに現在のキーを保存・即時反映する

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,10 @@
       "WebFetch(domain:github.com)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:raw.githubusercontent.com)",
-      "WebFetch(domain:developer.android.com)"
+      "WebFetch(domain:developer.android.com)",
+      "Bash(git checkout *)",
+      "Bash(adb devices *)",
+      "Bash(adb shell *)"
     ],
     "deny": []
   }

--- a/Presentation/src/main/java/com/neesan/presentation/player/PlayerUiState.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/player/PlayerUiState.kt
@@ -6,6 +6,7 @@ data class PlayerUiState(
     val videoId: String = "",
     val title: String = "",
     val thumbnailUrl: String = "",
+    val createdAt: Long = 0L,
     val currentKey: PitchKey = PitchKey(0.0),
     val isFavorite: Boolean = false,
     val isLoading: Boolean = false,

--- a/Presentation/src/main/java/com/neesan/presentation/player/PlayerUiState.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/player/PlayerUiState.kt
@@ -1,0 +1,12 @@
+package com.neesan.presentation.player
+
+import com.neesan.core.valueClass.PitchKey
+
+data class PlayerUiState(
+    val videoId: String = "",
+    val title: String = "",
+    val thumbnailUrl: String = "",
+    val currentKey: PitchKey = PitchKey(0.0),
+    val isFavorite: Boolean = false,
+    val isLoading: Boolean = false,
+)

--- a/Presentation/src/main/java/com/neesan/presentation/player/PlayerViewModel.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/player/PlayerViewModel.kt
@@ -34,7 +34,7 @@ class PlayerViewModel @Inject constructor(
 
     /**
      * 遷移パラメータで画面を初期化する。
-     * すでにお気に入り登録済みの場合は保存済みのキー値を復元する。
+     * すでにお気に入り登録済みの場合は保存済みのキー値と登録日を復元する。
      */
     fun initialize(destination: PlayerDestination) {
         if (initialized) return
@@ -51,16 +51,14 @@ class PlayerViewModel @Inject constructor(
 
         viewModelScope.launch {
             val isFavorite = checkIsFavoriteUseCase.invoke(destination.videoId).first()
-            val savedKey = if (isFavorite) {
-                getFavoriteVideoByIdUseCase.invoke(destination.videoId).first()?.keyValue
-                    ?: PitchKey(0.0)
-            } else {
-                PitchKey(0.0)
-            }
+            val savedFavorite = if (isFavorite) {
+                getFavoriteVideoByIdUseCase.invoke(destination.videoId).first()
+            } else null
             _uiState.update {
                 it.copy(
                     isFavorite = isFavorite,
-                    currentKey = savedKey,
+                    currentKey = savedFavorite?.keyValue ?: PitchKey(0.0),
+                    createdAt = savedFavorite?.createdAt ?: 0L,
                 )
             }
         }
@@ -68,10 +66,12 @@ class PlayerViewModel @Inject constructor(
 
     fun onPitchUp() {
         _uiState.update { it.copy(currentKey = it.currentKey + 1.0) }
+        persistKeyIfFavorited()
     }
 
     fun onPitchDown() {
         _uiState.update { it.copy(currentKey = it.currentKey - 1.0) }
+        persistKeyIfFavorited()
     }
 
     /**
@@ -85,19 +85,39 @@ class PlayerViewModel @Inject constructor(
         viewModelScope.launch {
             if (current.isFavorite) {
                 removeFavoriteVideoByIdUseCase.invoke(current.videoId)
-                _uiState.update { it.copy(isFavorite = false) }
+                _uiState.update { it.copy(isFavorite = false, createdAt = 0L) }
             } else {
+                val createdAt = System.currentTimeMillis()
                 addFavoriteVideoUseCase.invoke(
                     FavoriteVideoDomainData(
                         videoId = current.videoId,
                         title = current.title,
                         thumbnailUrl = current.thumbnailUrl,
-                        createdAt = System.currentTimeMillis(),
+                        createdAt = createdAt,
                         keyValue = current.currentKey,
                     )
                 )
-                _uiState.update { it.copy(isFavorite = true) }
+                _uiState.update { it.copy(isFavorite = true, createdAt = createdAt) }
             }
+        }
+    }
+
+    /**
+     * お気に入り登録済みの場合のみ、最新のキー値で永続化を上書きする。
+     */
+    private fun persistKeyIfFavorited() {
+        val state = _uiState.value
+        if (!state.isFavorite || state.videoId.isBlank()) return
+        viewModelScope.launch {
+            addFavoriteVideoUseCase.invoke(
+                FavoriteVideoDomainData(
+                    videoId = state.videoId,
+                    title = state.title,
+                    thumbnailUrl = state.thumbnailUrl,
+                    createdAt = state.createdAt.takeIf { it > 0L } ?: System.currentTimeMillis(),
+                    keyValue = state.currentKey,
+                )
+            )
         }
     }
 }

--- a/Presentation/src/main/java/com/neesan/presentation/player/PlayerViewModel.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/player/PlayerViewModel.kt
@@ -1,0 +1,103 @@
+package com.neesan.presentation.player
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.neesan.core.valueClass.PitchKey
+import com.neesan.domain.favorite.AddFavoriteVideoUseCase
+import com.neesan.domain.favorite.CheckIsFavoriteUseCase
+import com.neesan.domain.favorite.FavoriteVideoDomainData
+import com.neesan.domain.favorite.GetFavoriteVideoByIdUseCase
+import com.neesan.domain.favorite.RemoveFavoriteVideoByIdUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * 再生画面のViewModel
+ */
+@HiltViewModel
+class PlayerViewModel @Inject constructor(
+    private val addFavoriteVideoUseCase: AddFavoriteVideoUseCase,
+    private val removeFavoriteVideoByIdUseCase: RemoveFavoriteVideoByIdUseCase,
+    private val checkIsFavoriteUseCase: CheckIsFavoriteUseCase,
+    private val getFavoriteVideoByIdUseCase: GetFavoriteVideoByIdUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PlayerUiState())
+    val uiState: StateFlow<PlayerUiState> = _uiState
+
+    private var initialized = false
+
+    /**
+     * 遷移パラメータで画面を初期化する。
+     * すでにお気に入り登録済みの場合は保存済みのキー値を復元する。
+     */
+    fun initialize(destination: PlayerDestination) {
+        if (initialized) return
+        initialized = true
+
+        _uiState.update {
+            it.copy(
+                videoId = destination.videoId,
+                title = destination.title,
+                thumbnailUrl = destination.thumbnailUrl,
+                isFavorite = destination.isFavorite,
+            )
+        }
+
+        viewModelScope.launch {
+            val isFavorite = checkIsFavoriteUseCase.invoke(destination.videoId).first()
+            val savedKey = if (isFavorite) {
+                getFavoriteVideoByIdUseCase.invoke(destination.videoId).first()?.keyValue
+                    ?: PitchKey(0.0)
+            } else {
+                PitchKey(0.0)
+            }
+            _uiState.update {
+                it.copy(
+                    isFavorite = isFavorite,
+                    currentKey = savedKey,
+                )
+            }
+        }
+    }
+
+    fun onPitchUp() {
+        _uiState.update { it.copy(currentKey = it.currentKey + 1.0) }
+    }
+
+    fun onPitchDown() {
+        _uiState.update { it.copy(currentKey = it.currentKey - 1.0) }
+    }
+
+    /**
+     * お気に入り状態を切り替える。
+     * 追加時は現在のキーをそのまま保存する。
+     */
+    fun toggleFavorite() {
+        val current = _uiState.value
+        if (current.videoId.isBlank()) return
+
+        viewModelScope.launch {
+            if (current.isFavorite) {
+                removeFavoriteVideoByIdUseCase.invoke(current.videoId)
+                _uiState.update { it.copy(isFavorite = false) }
+            } else {
+                addFavoriteVideoUseCase.invoke(
+                    FavoriteVideoDomainData(
+                        videoId = current.videoId,
+                        title = current.title,
+                        thumbnailUrl = current.thumbnailUrl,
+                        createdAt = System.currentTimeMillis(),
+                        keyValue = current.currentKey,
+                    )
+                )
+                _uiState.update { it.copy(isFavorite = true) }
+            }
+        }
+    }
+}

--- a/Presentation/src/main/java/com/neesan/presentation/player/VideoPlayerScreen.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/player/VideoPlayerScreen.kt
@@ -8,22 +8,34 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.media3.common.util.UnstableApi
+import com.neesan.core.valueClass.PitchKey
 import com.neesan.presentation.isPreview
 import com.neesan.presentation.player.section.PlayerSection
 import kotlinx.serialization.Serializable
@@ -82,16 +94,37 @@ private class AudioResourceMonitoringWebViewClient(
  * 動画再生画面。音声リソースの検出とURLの表示機能付き
  */
 @Composable
-fun VideoPlayerScreen(destination: PlayerDestination) {
+fun VideoPlayerScreen(
+    destination: PlayerDestination,
+    viewModel: PlayerViewModel = hiltViewModel(),
+) {
+    LaunchedEffect(destination.videoId) {
+        viewModel.initialize(destination)
+    }
+    val uiState by viewModel.uiState.collectAsState()
+
     VideoPlayerContent(
-        videoId = destination.videoId,
-        title = destination.title
+        videoId = uiState.videoId.ifBlank { destination.videoId },
+        title = uiState.title.ifBlank { destination.title },
+        currentKey = uiState.currentKey,
+        isFavorite = uiState.isFavorite,
+        onPitchUp = viewModel::onPitchUp,
+        onPitchDown = viewModel::onPitchDown,
+        onToggleFavorite = viewModel::toggleFavorite,
     )
 }
 
 @androidx.annotation.OptIn(UnstableApi::class)
 @Composable
-private fun VideoPlayerContent(videoId: String, title: String) {
+private fun VideoPlayerContent(
+    videoId: String,
+    title: String,
+    currentKey: PitchKey,
+    isFavorite: Boolean,
+    onPitchUp: () -> Unit,
+    onPitchDown: () -> Unit,
+    onToggleFavorite: () -> Unit,
+) {
     // 検出された音声URLを保存するリスト
     val detectedAudioUrls = remember { mutableStateListOf<String>() }
     var streamingUrl by remember { mutableStateOf<String?>(null) }
@@ -104,10 +137,24 @@ private fun VideoPlayerContent(videoId: String, title: String) {
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
-        Text(
-            text = "動画ID: $videoId\nタイトル: $title",
-            modifier = Modifier.padding(16.dp)
-        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "動画ID: $videoId\nタイトル: $title",
+                modifier = Modifier.weight(1f),
+            )
+            IconButton(onClick = onToggleFavorite) {
+                Icon(
+                    imageVector = if (isFavorite) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
+                    contentDescription = if (isFavorite) "お気に入りから削除" else "お気に入りに追加",
+                    tint = if (isFavorite) Color.Red else MaterialTheme.colorScheme.onSurface,
+                )
+            }
+        }
 
         // WebViewで音声URLを検出
         if (!isPreview()) {
@@ -145,6 +192,9 @@ private fun VideoPlayerContent(videoId: String, title: String) {
             // ExoPlayerを使用したストリーミング再生
             PlayerSection(
                 streamingUrl = streamingUrl,
+                currentKey = currentKey,
+                onPitchUp = onPitchUp,
+                onPitchDown = onPitchDown,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(16.dp)
@@ -165,5 +215,13 @@ private fun VideoPlayerContent(videoId: String, title: String) {
 @Preview(showBackground = true)
 @Composable
 private fun PreviewVideoPlayerContent() {
-    VideoPlayerContent(videoId = "sm12345678", title = "サンプル動画")
+    VideoPlayerContent(
+        videoId = "sm12345678",
+        title = "サンプル動画",
+        currentKey = PitchKey(0.0),
+        isFavorite = false,
+        onPitchUp = {},
+        onPitchDown = {},
+        onToggleFavorite = {},
+    )
 }

--- a/Presentation/src/main/java/com/neesan/presentation/player/section/PlayerSection.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/player/section/PlayerSection.kt
@@ -65,6 +65,9 @@ fun PlayerSection(
             // ExoPlayerにHLS MediaSourceを設定
             player?.setMediaSource(hlsMediaSource)
             player?.prepare()
+            // メディア準備完了時点の currentKey を必ず反映する
+            // （LaunchedEffect(currentKey) との実行順が前後しても確実に適用するための保険）
+            updatePitch(player, currentKey)
         }
     }
 

--- a/Presentation/src/main/java/com/neesan/presentation/player/section/PlayerSection.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/player/section/PlayerSection.kt
@@ -11,10 +11,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -37,11 +34,13 @@ import kotlin.math.pow
 @Composable
 fun PlayerSection(
     streamingUrl: String?,
+    currentKey: PitchKey,
+    onPitchUp: () -> Unit,
+    onPitchDown: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val isPreview = isPreview()
-    var currentKey by remember { mutableStateOf(PitchKey(0.0)) }
 
     val player = remember {
         if (isPreview) {
@@ -98,8 +97,8 @@ fun PlayerSection(
         }
         PitchControllerComponent(
             currentKey = currentKey,
-            onPitchUp = { currentKey += 1.0 },
-            onPitchDown = { currentKey -= 1.0 }
+            onPitchUp = onPitchUp,
+            onPitchDown = onPitchDown
         )
     }
 }
@@ -121,6 +120,9 @@ private fun generatePitchFrequency(key: PitchKey): Float {
 private fun PreviewPlayerSection() {
     PlayerSection(
         streamingUrl = "https://example.com/stream.m3u8",
+        currentKey = PitchKey(0.0),
+        onPitchUp = {},
+        onPitchDown = {},
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp)


### PR DESCRIPTION
## Summary
- プレイヤー画面に♡ボタンを追加し、お気に入り登録時に現在のキー値を `keyValue` として保存
- お気に入り登録済みの動画でキーを ♯/♭ 操作した際に DB を即座に上書き更新し、お気に入り一覧の表示にも反映されるように修正
- 既登録動画を再度開いたとき、保存済みキーで再生ピッチを復元（`prepare()` 直後にも `updatePitch` を呼ぶ保険つき）

## Test plan
- [x] Search 画面から動画を再生 → キーを変更してお気に入り登録 → 一覧の Key 表示が登録時のキーになっていること
- [x] 上記でお気に入り登録済みの動画を再度開く → ピッチコントローラと再生音が保存済みキーで復元されること
- [x] お気に入り登録済みの動画でプレイヤー画面のキーを変更 → タブを切り替えてお気に入り一覧に戻ると Key 表示が更新されていること
- [x] ♡ボタンで OFF → ON した際に最新の調整キーで再登録されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)