### PR TITLE
検索バーでEnterキーによる検索実行を可能にする (#30)

### DIFF
--- a/Presentation/src/main/java/com/neesan/presentation/search/SearchScreen.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/search/SearchScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
@@ -34,6 +36,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -85,6 +89,7 @@ private fun SearchContent(
     onVideoClick: (VideoDomainModel) -> Unit = {}
 ) {
     var searchQuery by remember { mutableStateOf("") }
+    val keyboardController = LocalSoftwareKeyboardController.current
 
     val requestPermissionLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
@@ -120,7 +125,10 @@ private fun SearchContent(
                 modifier = Modifier.fillMaxWidth(),
                 label = { Text("検索キーワード") },
                 leadingIcon = {
-                    IconButton(onClick = { onSearch(searchQuery) }) {
+                    IconButton(onClick = {
+                        keyboardController?.hide()
+                        onSearch(searchQuery)
+                    }) {
                         Icon(Icons.Default.Search, contentDescription = "検索")
                     }
                 },
@@ -134,7 +142,14 @@ private fun SearchContent(
                         }
                     }
                 },
-                singleLine = true
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(
+                    onSearch = {
+                        keyboardController?.hide()
+                        onSearch(searchQuery)
+                    }
+                )
             )
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/Presentation/src/main/java/com/neesan/presentation/search/SearchScreen.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/search/SearchScreen.kt
@@ -90,6 +90,10 @@ private fun SearchContent(
 ) {
     var searchQuery by remember { mutableStateOf("") }
     val keyboardController = LocalSoftwareKeyboardController.current
+    val executeSearch = {
+        keyboardController?.hide()
+        onSearch(searchQuery)
+    }
 
     val requestPermissionLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
@@ -125,10 +129,7 @@ private fun SearchContent(
                 modifier = Modifier.fillMaxWidth(),
                 label = { Text("検索キーワード") },
                 leadingIcon = {
-                    IconButton(onClick = {
-                        keyboardController?.hide()
-                        onSearch(searchQuery)
-                    }) {
+                    IconButton(onClick = { executeSearch() }) {
                         Icon(Icons.Default.Search, contentDescription = "検索")
                     }
                 },
@@ -144,12 +145,7 @@ private fun SearchContent(
                 },
                 singleLine = true,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                keyboardActions = KeyboardActions(
-                    onSearch = {
-                        keyboardController?.hide()
-                        onSearch(searchQuery)
-                    }
-                )
+                keyboardActions = KeyboardActions(onSearch = { executeSearch() })
             )
 
             Spacer(modifier = Modifier.height(16.dp))


### PR DESCRIPTION
Closes #30

## Summary
- `OutlinedTextField` に `imeAction = ImeAction.Search` を設定し、キーボードのEnter（検索）キーで検索が走るようにした
- `KeyboardActions.onSearch` と検索アイコンの `onClick` の双方で `LocalSoftwareKeyboardController.hide()` を呼び、検索実行と同時にソフトキーボードを閉じるようにした
- 既存の検索アイコンタップでの検索フローは従来通り動作

## Test plan
- [x] 検索画面でキーワードを入力後、ソフトキーボードのEnter（検索）キー押下で検索が実行されることを確認
- [x] 検索実行時にソフトキーボードが閉じることを確認
- [x] 検索アイコンタップでも従来通り検索できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)