### PR TITLE
検索結果のお気に入り状態をDBのFlowと連動させる (#31)

### DIFF
--- a/Domain/src/main/java/com/neesan/domain/search/SearchVideoUseCase.kt
+++ b/Domain/src/main/java/com/neesan/domain/search/SearchVideoUseCase.kt
@@ -3,8 +3,7 @@ package com.neesan.domain.search
 import com.neesan.data.favorite.FavoriteRepository
 import com.neesan.data.search.SearchRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.combine
 import javax.inject.Inject
 
 /**
@@ -16,6 +15,9 @@ class SearchVideoUseCase @Inject constructor(
 ) {
     /**
      * キーワードで動画を検索する
+     *
+     * お気に入りDBのFlowと結合しているため、お気に入り一覧側で追加/削除されると
+     * 検索結果のisFavoriteも自動的に最新化される。
      *
      * @param query 検索キーワード
      * @param targets 検索対象（デフォルトはタイトル）
@@ -30,17 +32,13 @@ class SearchVideoUseCase @Inject constructor(
         sort: String = "-viewCounter",
         limit: Int = 100
     ): Flow<List<VideoDomainModel>> {
-        return flow {
-            searchRepository.searchVideos(query, targets, sort, limit).collect {
-                // 取得した動画リストをVideoMapperを使って変換
-                val videos = it.data.map { video ->
-                    val videoDomainModel = VideoMapper.toVideoDomainModel(video)
-                    // お気に入り状態を確認
-                    val isFavorite = favoriteRepository.isFavorite(videoDomainModel.id).first()
-                    videoDomainModel.copy(isFavorite = isFavorite)
+        return searchRepository.searchVideos(query, targets, sort, limit)
+            .combine(favoriteRepository.getAllFavoriteVideos()) { response, favorites ->
+                val favoriteIds = favorites.mapTo(mutableSetOf()) { it.videoId }
+                response.data.map { video ->
+                    VideoMapper.toVideoDomainModel(video)
+                        .copy(isFavorite = favoriteIds.contains(video.contentId))
                 }
-                emit(videos)
             }
-        }
     }
 }

--- a/Domain/src/test/java/com/neesan/domain/search/SearchVideoUseCaseTest.kt
+++ b/Domain/src/test/java/com/neesan/domain/search/SearchVideoUseCaseTest.kt
@@ -1,13 +1,21 @@
 package com.neesan.domain.search
 
 import com.neesan.data.favorite.FavoriteRepository
+import com.neesan.data.favorite.FavoriteVideoEntity
 import com.neesan.data.search.SearchRepository
 import com.neesan.data.search.SearchVideoResponse
 import com.neesan.data.search.Video
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
@@ -34,16 +42,15 @@ class SearchVideoUseCaseTest {
             Video(contentId = "1", title = "テスト動画1", viewCounter = 1000, thumbnailUrl = "url1"),
             Video(contentId = "2", title = "テスト動画2", viewCounter = 2000, thumbnailUrl = "url2")
         )
-        
+
         // モックの振る舞いを設定
         whenever(searchRepository.searchVideos("テスト", "title", "-viewCounter", 100))
-            .thenReturn(flow { 
-                emit(SearchVideoResponse(mockVideos)) 
+            .thenReturn(flow {
+                emit(SearchVideoResponse(mockVideos))
             })
-        
-        // お気に入り状態のモック設定（すべてfalse）
-        whenever(favoriteRepository.isFavorite("1")).thenReturn(flow { emit(false) })
-        whenever(favoriteRepository.isFavorite("2")).thenReturn(flow { emit(false) })
+
+        // お気に入り一覧は空
+        whenever(favoriteRepository.getAllFavoriteVideos()).thenReturn(flowOf(emptyList()))
 
         // テスト実行
         val result = searchVideoUseCase.invoke("テスト").first()
@@ -54,5 +61,64 @@ class SearchVideoUseCaseTest {
         assertEquals("テスト動画1", result[0].title)
         assertEquals(1000, result[0].viewCount)
         assertEquals("url1", result[0].thumbnailUrl)
+        assertFalse(result[0].isFavorite)
+        assertFalse(result[1].isFavorite)
+    }
+
+    @Test
+    fun お気に入り済みの動画はisFavoriteがtrueになること() = runTest {
+        val mockVideos = listOf(
+            Video(contentId = "1", title = "テスト動画1", viewCounter = 1000, thumbnailUrl = "url1"),
+            Video(contentId = "2", title = "テスト動画2", viewCounter = 2000, thumbnailUrl = "url2")
+        )
+
+        whenever(searchRepository.searchVideos("テスト", "title", "-viewCounter", 100))
+            .thenReturn(flowOf(SearchVideoResponse(mockVideos)))
+
+        whenever(favoriteRepository.getAllFavoriteVideos()).thenReturn(
+            flowOf(
+                listOf(
+                    FavoriteVideoEntity(videoId = "1", title = "テスト動画1", thumbnailUrl = "url1")
+                )
+            )
+        )
+
+        val result = searchVideoUseCase.invoke("テスト").first()
+
+        assertEquals(2, result.size)
+        assertTrue(result[0].isFavorite)
+        assertFalse(result[1].isFavorite)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun お気に入りFlowの更新が検索結果のisFavoriteに反映されること() = runTest {
+        val mockVideos = listOf(
+            Video(contentId = "1", title = "テスト動画1", viewCounter = 1000, thumbnailUrl = "url1")
+        )
+
+        whenever(searchRepository.searchVideos("テスト", "title", "-viewCounter", 100))
+            .thenReturn(flowOf(SearchVideoResponse(mockVideos)))
+
+        val favoritesFlow = MutableStateFlow<List<FavoriteVideoEntity>>(
+            listOf(FavoriteVideoEntity(videoId = "1", title = "テスト動画1", thumbnailUrl = "url1"))
+        )
+        whenever(favoriteRepository.getAllFavoriteVideos()).thenReturn(favoritesFlow)
+
+        val emissions = mutableListOf<List<VideoDomainModel>>()
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            searchVideoUseCase.invoke("テスト").collect { emissions.add(it) }
+        }
+
+        // 初回: お気に入り済み
+        assertEquals(1, emissions.size)
+        assertTrue(emissions[0][0].isFavorite)
+
+        // お気に入りから削除されると再emitされ、isFavoriteがfalseになる
+        favoritesFlow.value = emptyList()
+        assertEquals(2, emissions.size)
+        assertFalse(emissions[1][0].isFavorite)
+
+        job.cancel()
     }
 }

--- a/Presentation/src/main/java/com/neesan/presentation/search/SearchVideoViewModel.kt
+++ b/Presentation/src/main/java/com/neesan/presentation/search/SearchVideoViewModel.kt
@@ -137,22 +137,15 @@ class SearchVideoViewModel @Inject constructor(
 
     /**
      * お気に入り状態を切り替える
+     *
+     * DB更新後の反映は SearchVideoUseCase が公開するFlow経由で行われるため、
+     * ここではDB書き込みのみ行う。
      */
     fun toggleFavorite(video: VideoDomainModel) {
         viewModelScope.launch {
             if (video.isFavorite) {
-                // お気に入りから削除
                 removeFavoriteVideoByIdUseCase.invoke(video.id)
-                // UI状態を更新
-                _uiState.update { currentState ->
-                    currentState.copy(
-                        videos = currentState.videos.map { 
-                            if (it.id == video.id) it.copy(isFavorite = false) else it
-                        }
-                    )
-                }
             } else {
-                // お気に入りに追加
                 val favoriteVideo = FavoriteVideoDomainData(
                     videoId = video.id,
                     title = video.title,
@@ -160,14 +153,6 @@ class SearchVideoViewModel @Inject constructor(
                     createdAt = System.currentTimeMillis(),
                 )
                 addOrUpdateFavoriteVideoUseCase.invoke(favoriteVideo)
-                // UI状態を更新
-                _uiState.update { currentState ->
-                    currentState.copy(
-                        videos = currentState.videos.map { 
-                            if (it.id == video.id) it.copy(isFavorite = true) else it
-                        }
-                    )
-                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- お気に入り一覧側で削除しても、検索結果のハートが活性化したまま残る不具合 (#31) を修正
- `SearchVideoUseCase` で検索結果 Flow と `favoriteRepository.getAllFavoriteVideos()` を `combine` して、お気に入りDBの変更が自動的に `isFavorite` に反映されるようにした
- `SearchVideoViewModel.toggleFavorite` のローカル状態手書き更新を削除し、Flow経由の更新に一本化（DBを単一の真実源に）

Closes #31

## 受け入れ条件の確認
- [x] お気に入り一覧で削除した動画は、検索結果側のハートも非活性に戻る（`combine` の再emitで反映）
- [x] お気に入り追加時も同様にリアルタイムで反映される

## Test plan
- [x] `./gradlew :Domain:test` 合格（既存テスト含む、追加した2件のFlow連動テストも合格）
- [x] `./gradlew :Presentation:test` 合格
- [x] `./gradlew :app:test` 合格
- [x] 実機/エミュレーターで再現手順を実施し、削除/追加がリアルタイム反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)